### PR TITLE
Add product site, README, and docs infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,19 @@ CI signing is convenient for automation. Developer signing is stronger for trust
 - **Impersonation** — Signer identity is bound to a Fulcio certificate via GitHub OIDC; forgery fails verification
 - **Supply chain risk** — The SKILL.md file itself is signed; tampering with the skill content is detected (does not cover transitive dependencies)
 
+## Roadmap
+
+| Phase | Milestone | Status | Summary |
+|-------|-----------|--------|---------|
+| **1. MVP** | `v0.1-mvp` | **15/15 done** | End-to-end sign and verify through real Sigstore. Canonical form, digest, OIDC auth, signing engine, sidecar read/write, verification engine, TUF client, CLI commands, exit codes, test suite. |
+| **2. Hardening** | `v0.1-hardening` | Not started | `--strict` mode, `--offline` mode, `inspect`/`unsign` commands, `--format json`, all error flows with correct exit codes. |
+| **3. Adoption** | `v0.1-adoption` | Not started | Policy engine, `signer_org` matching, `max_age_days`, GitHub Actions example workflow, PyPI + Homebrew distribution. |
+| **4. Ecosystem** | `v0.2-planning` | Not started | Co-signing, registry specification, Claude Code native integration, non-GitHub identity providers. |
+
+Open work items: [#16](https://github.com/bruk-io/skillsign/issues/16) (QA e2e), [#18](https://github.com/bruk-io/skillsign/issues/18) (SET strict mode), [#20](https://github.com/bruk-io/skillsign/issues/20) (worktree cleanup).
+
+See [`docs/roadmap.md`](docs/roadmap.md) for the full breakdown.
+
 ## Requirements
 
 - Python 3.14+


### PR DESCRIPTION
## Summary
- Astro 5 product site with bh-01 Web Components (landing, how-it-works, getting-started)
- MkDocs Material scaffolding for developer docs
- GitHub Pages workflow (builds Astro + MkDocs, deploys combined artifact)
- README with quick start, signing modes (CI vs developer), roadmap progress, and project overview
- C4 architecture model synced with codebase

## Test plan
- [x] `cd site && npm run build` passes
- [x] All threat model claims reviewed for spec accuracy
- [x] Roadmap progress matches GitHub issue state (Phase 1: 15/15 closed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)