### PR TITLE
Fix architecture base path and README links

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -41,7 +41,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Build all assets
-        run: make build
+        run: make build VERSION="$DEPLOY_VERSION" BASE_PREFIX="/${{ github.event.repository.name }}"
 
       - name: Deploy to gh-pages
         run: |

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 BUILD_DIR := _build
 VERSION ?= main
+# Base path prefix for GitHub Pages (e.g. /skillsign for bruk-io.github.io/skillsign)
+# Set to empty string when using a custom domain (skillsign.ai)
+BASE_PREFIX ?= /skillsign
 
 .PHONY: build build-site build-docs build-architecture clean deploy
 
@@ -17,7 +20,7 @@ build-docs:
 	@$(MAKE) -C docs build
 
 build-architecture:
-	@$(MAKE) -C architecture build
+	@$(MAKE) -C architecture build BASE_URL="$(BASE_PREFIX)/$(VERSION)/architecture/"
 
 clean:
 	@$(MAKE) -C site clean

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ skillsign/
 │   └── errors.py       # Error types and exit codes
 ├── tests/              # Unit, integration, and e2e tests
 ├── architecture/       # C4 model (LikeC4 DSL)
-├── site/               # Product website (Astro + bh-01)
+├── site/               # Product website (HTML + bh-01)
 ├── docs/               # Developer docs (MkDocs)
 └── pyproject.toml
 ```
@@ -129,8 +129,9 @@ skillsign/
 ## Documentation
 
 - [Specification](docs/spec.md) — v0.1 draft, the source of truth for all behavior
-- [Product site](https://bruk-io.github.io/skillsign/) — Overview, how it works, getting started
-- [Dev docs](https://bruk-io.github.io/skillsign/docs/) — API reference and developer guides
+- [Product site](https://bruk-io.github.io/skillsign/main/) — Overview, how it works, getting started
+- [Dev docs](https://bruk-io.github.io/skillsign/main/docs/) — API reference and developer guides
+- [Architecture](https://bruk-io.github.io/skillsign/main/architecture/) — Interactive C4 diagrams (LikeC4)
 
 ## License
 

--- a/architecture/Makefile
+++ b/architecture/Makefile
@@ -1,10 +1,11 @@
 BUILD_DIR ?= _build
+BASE_URL ?= /
 
 .PHONY: build clean validate
 
 build: validate
-	@npx likec4 build -o $(BUILD_DIR)
-	@echo "architecture: built to $(BUILD_DIR)/"
+	@npx likec4 build -o $(BUILD_DIR) --base "$(BASE_URL)"
+	@echo "architecture: built to $(BUILD_DIR)/ (base: $(BASE_URL))"
 
 validate:
 	@npx likec4 validate


### PR DESCRIPTION
## Summary
- Pass `--base` flag to LikeC4 build so assets load from `/skillsign/<version>/architecture/` instead of root `/`
- Fix README: site/ description (HTML not Astro), add `/main/` version prefix to page links, add architecture link

## Test plan
- [ ] CI passes
- [ ] After merge, `https://bruk-io.github.io/skillsign/main/architecture/` loads correctly with all assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)